### PR TITLE
Out of Stock Product 404 Fix

### DIFF
--- a/src/Model/Resolver/EntityUrl.php
+++ b/src/Model/Resolver/EntityUrl.php
@@ -10,33 +10,24 @@ declare(strict_types=1);
 
 namespace ScandiPWA\UrlrewriteGraphQl\Model\Resolver;
 
-use Magento\Catalog\Api\CategoryRepositoryInterface;
 use Magento\Catalog\Model\Product\Attribute\Source\Status;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
-use Magento\CatalogInventory\Api\StockStateInterface;
-use Magento\CatalogInventory\Model\Stock\StockItemRepository;
-use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
-use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
-use Magento\Store\Model\ScopeInterface;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\UrlRewrite\Model\UrlFinderInterface;
 use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
 use Magento\UrlRewriteGraphQl\Model\Resolver\UrlRewrite\CustomUrlLocatorInterface;
+use Magento\Catalog\Api\CategoryRepositoryInterface;
 
 /**
  * UrlRewrite field resolver, used for GraphQL request processing.
  */
 class EntityUrl implements ResolverInterface
 {
-    /**
-     * Config key 'Display Out of Stock Products'
-     */
-    const XML_PATH_CATALOGINVENTORY_SHOW_OUT_OF_STOCK = 'cataloginventory/options/show_out_of_stock';
-
     /**
      * @var UrlFinderInterface
      */
@@ -63,48 +54,24 @@ class EntityUrl implements ResolverInterface
     private $categoryRepository;
 
     /**
-     * @var StockItemRepository
-     */
-    private $stockItemRepository;
-
-    /**
-     * @var ScopeConfigInterface
-     */
-    private $scopeConfig;
-
-    /**
-     * @var StockStateInterface
-     */
-    private $stockState;
-
-    /**
      * @param UrlFinderInterface $urlFinder
      * @param StoreManagerInterface $storeManager
      * @param CustomUrlLocatorInterface $customUrlLocator
      * @param CollectionFactory $productCollectionFactory
      * @param CategoryRepositoryInterface $categoryRepository
-     * @param StockItemRepository $stockItemRepository
-     * @param ScopeConfigInterface $scopeConfig
-     * @param StockStateInterface $stockState
      */
     public function __construct(
         UrlFinderInterface $urlFinder,
         StoreManagerInterface $storeManager,
         CustomUrlLocatorInterface $customUrlLocator,
         CollectionFactory $productCollectionFactory,
-        CategoryRepositoryInterface $categoryRepository,
-        StockItemRepository $stockItemRepository,
-        ScopeConfigInterface $scopeConfig,
-        StockStateInterface $stockState
+        CategoryRepositoryInterface $categoryRepository
     ) {
         $this->urlFinder = $urlFinder;
         $this->storeManager = $storeManager;
         $this->customUrlLocator = $customUrlLocator;
         $this->productCollectionFactory = $productCollectionFactory;
         $this->categoryRepository = $categoryRepository;
-        $this->stockItemRepository = $stockItemRepository;
-        $this->scopeConfig = $scopeConfig;
-        $this->stockState = $stockState;
     }
 
     /**
@@ -147,34 +114,7 @@ class EntityUrl implements ResolverInterface
                 $collection = $this->productCollectionFactory->create()
                     ->addAttributeToFilter('status', ['eq' => Status::STATUS_ENABLED]);
                 $product = $collection->addIdFilter($id)->getFirstItem();
-                $isInStock = false;
-
-                switch ($product['type_id']) {
-                    case 'configurable':
-                        $isInStock = $this->getConfigurableProductStockState($product);
-                        break;
-                    case 'bundle':
-                        $isInStock = $this->getBundleProductsStockState($this->getBundleProductChildrenItems($product, $id));
-                        break;
-                    default:
-                        try {
-                            $isInStock = $this->stockItemRepository->get($id)->getIsInStock();
-                        } catch (NoSuchEntityException $e) {
-                            // Ignoring error is safe
-                        }
-                    break;
-                }
-
-                $isOutOfStockDisplay = $this->scopeConfig->getValue(
-                    self::XML_PATH_CATALOGINVENTORY_SHOW_OUT_OF_STOCK,
-                    ScopeInterface::SCOPE_STORE
-                );
-
-                /*
-                 * return 404 page if product has no data
-                 * or out of stock product display is disabled
-                 */
-                if (!$product->hasData() || !$isOutOfStockDisplay && !$isInStock) {
+                if (!$product->hasData()) {
                     return null;
                 }
 
@@ -256,37 +196,5 @@ class EntityUrl implements ResolverInterface
     private function sanitizeType(string $type) : string
     {
         return strtoupper(str_replace('-', '_', $type));
-    }
-
-    private function getBundleProductChildrenItems($product, $id)
-    {
-        $typeInstance = $product->getTypeInstance();
-        return $typeInstance->getChildrenIds($id, true);
-    }
-
-    private function getBundleProductsStockState($childrenProductsCollection) : bool
-    {
-        $total_stock = 0;
-        foreach ($childrenProductsCollection as $value) {
-            foreach ($value as $concreteIndex) {
-                $total_stock += $this->stockState->getStockQty($concreteIndex);
-            }
-        }
-
-        return $total_stock > 0;
-    }
-
-    private function getConfigurableProductStockState($product) : bool
-    {
-        $totalStock = 0;
-        if ($product->getTypeID() === 'configurable') {
-            $productTypeInstance = $product->getTypeInstance();
-            $usedProducts = $productTypeInstance->getUsedProducts($product);
-            foreach ($usedProducts as $simple) {
-                $totalStock += $this->stockState->getStockQty($simple->getId(), $simple->getStore()->getWebsiteId());
-            }
-        }
-
-        return $totalStock > 0;
     }
 }


### PR DESCRIPTION
Fixes scandipwa/scandipwa#2221
Removed out of stock detection logic from url rewrite module since magento should display product page by direct urls even if Shou Out Of Stock Product In Categories option is set to No.